### PR TITLE
std::auto_ptr -> std::unique_ptr to compile in 9X

### DIFF
--- a/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEvents.cc
+++ b/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEvents.cc
@@ -118,9 +118,9 @@ bool RemovePileUpDominatedEvents::filter(edm::Event& iEvent, const edm::EventSet
    			if(tmp<dR) dR=tmp;
    		}
    }
-   std::auto_ptr<float> pOut(new float());
+   auto pOut = std::make_unique<float>();
    *pOut=dR;
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
    if (dR<deltaR_) return true;
    return false;
 }

--- a/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEventsGen.cc
+++ b/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEventsGen.cc
@@ -93,9 +93,9 @@ bool RemovePileUpDominatedEventsGen::filter(edm::Event& iEvent, const edm::Event
    signal_pT_hat = generatorInfo->qScale();
 
    //save PU - signal pt-hat
-   std::auto_ptr<float> pOut(new float());
+   auto pOut = std::make_unique<float>();
    *pOut=signal_pT_hat-pu_pT_hat_max;   
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
 
    //filter the event
    if (signal_pT_hat>pu_pT_hat_max) return true;

--- a/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEventsGenV2.cc
+++ b/RemovePileUpDominatedEvents/plugins/RemovePileUpDominatedEventsGenV2.cc
@@ -134,9 +134,9 @@ bool RemovePileUpDominatedEventsGenV2::filter(edm::Event& iEvent, const edm::Eve
    if(genJets.product()->size()>0) signal_genJetPt = genJets.product()->at(0).pt();
 
    //save PU - signal genJetPt
-   std::auto_ptr<float> pOut(new float());
+   auto pOut = std::make_unique<float>();
    *pOut=signal_genJetPt-pu_genJetPt_max;   
-   iEvent.put(pOut);
+   iEvent.put(std::move(pOut));
 
    //filter the event
    if (signal_genJetPt>pu_genJetPt_max) return true;


### PR DESCRIPTION
Dear Steam,

This doesnt work in 9X due to the std::auto_ptr -> std::unique_ptr migration. Here is the trivial fix (which will work in 8X too) to save others some time. 

Best,
Sam